### PR TITLE
Moat fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,16 @@ setup: device
 device:
 	mkdir device
 run/%:
-	@make DEV=$(notdir $@) NO_BURN=y
+	@gmake DEV=$(notdir $@) NO_BURN=y
 
 targets:
 	./cfg ${CFG} targets
 
 burn_%:
 	@echo BURN $(subst burn_,,$@)
-	@make DEV=$(subst burn_,,$@) burn
+	@gmake DEV=$(subst burn_,,$@) burn
 %:
-	@make DEV=$@ all
+	@gmake DEV=$@ all
 	
 clean:
 	rm -r device

--- a/cfg
+++ b/cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 This program is part of MoaT.

--- a/cfg_write
+++ b/cfg_write
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 This program is part of MoaT.

--- a/gen_eeprom
+++ b/gen_eeprom
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf8 -*-
 
 ## generate / write a device configuration file.

--- a/moat.c
+++ b/moat.c
@@ -130,7 +130,9 @@ static void moat_read(void)
 
 	switch(dtype) {
 	case TC_CONFIG: read_config(crc); break;
+#ifdef TC_CONSOLE
 	case TC_CONSOLE: read_console(crc); break;
+#endif
 	default: DBG_C('?'); return;
 	}
 }

--- a/moat_internal.h
+++ b/moat_internal.h
@@ -26,7 +26,7 @@ void end_transmission(uint16_t crc);
 #ifdef TC_CONSOLE
 void read_console(uint16_t crc);
 #else
-#define read_console(uint16_t crc) do{}while(0);
+#define read_console(crc) do{}while(0);
 #endif
 
 #endif // moat_internal.h


### PR DESCRIPTION
Hi,

some fixes trying to get building to work in this pull request.

However, I still fail getting it to work.

`gmake ds2423` fails with the following:
```
avr-objcopy -I binary -O elf32-avr --prefix-sections=.progmem \
        --redefine-sym "_binary_device_ds2423_eprom_bin_start=_config_start" \
        --redefine-sym "_binary_device_ds2423_eprom_bin_size=_config_size" \
        --redefine-sym "_binary_device_ds2423_eprom_bin_end=_config_end" \
        device/ds2423/eprom.bin device/ds2423/config.o
gmake[1]: *** No rule to make target 'device/ds2423/moat__ref.o', needed by 'device/ds2423/image.elf'.  Stop.
gmake[1]: Leaving directory '/usr/home/johan/dev/avr/moat'
Makefile:29: recipe for target 'ds2423' failed
gmake: *** [ds2423] Error 2
```

Interesting project either way, I will probably try to port my existing ow code (not-so-well-working @ 8Mhz, based on the older owslave code) to the new onewire.c architecture, if not also to the moat device.